### PR TITLE
Implemented digest auth and ACLs

### DIFF
--- a/docs/data-sources/znode.md
+++ b/docs/data-sources/znode.md
@@ -44,10 +44,21 @@ output "best_team_znode_data_base64" {
 
 ### Read-Only
 
+- `acl` (List of Object) List of ACL entries for the ZNode. (see [below for nested schema](#nestedatt--acl))
 - `data` (String) Content of the ZNode. Use this if content is a UTF-8 string.
 - `data_base64` (String) Content of the ZNode, encoded in Base64. Use this if content is binary (i.e. sequence of bytes).
 - `id` (String) The ID of this resource.
 - `stat` (List of Object) [ZooKeeper Stat Structure](https://zookeeper.apache.org/doc/current/zookeeperProgrammers.html#sc_zkStatStructure) of the ZNode. More details about `stat` can be found [here](../../docs#the-stat-structure). (see [below for nested schema](#nestedatt--stat))
+
+<a id="nestedatt--acl"></a>
+### Nested Schema for `acl`
+
+Read-Only:
+
+- `id` (String)
+- `permissions` (Number)
+- `scheme` (String)
+
 
 <a id="nestedatt--stat"></a>
 ### Nested Schema for `stat`

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,8 +60,10 @@ provider "zookeeper" {
 
 ### Optional
 
+- `password` (String, Sensitive) Password for digest authentication
 - `servers` (String) A comma separated list of 'host:port' pairs, pointing at ZooKeeper Server(s).
 - `session_timeout` (Number) How many seconds a session is considered valid after losing connectivity. More information about ZooKeeper sessions can be found [here](#zookeeper-sessions).
+- `username` (String, Sensitive) Username for digest authentication
 
 ## Important aspects about ZooKeeper and this provider
 

--- a/docs/resources/sequential_znode.md
+++ b/docs/resources/sequential_znode.md
@@ -62,6 +62,7 @@ resource "zookeeper_sequential_znode" "seqC" {
 
 ### Optional
 
+- `acl` (Block List) List of ACL entries for the ZNode. (see [below for nested schema](#nestedblock--acl))
 - `data` (String) Content to store in the ZNode, as a UTF-8 string. Mutually exclusive with `data_base64`.
 - `data_base64` (String) Content to store in the ZNode, as Base64 encoded bytes. Mutually exclusive with `data`.
 
@@ -70,6 +71,16 @@ resource "zookeeper_sequential_znode" "seqC" {
 - `id` (String) The ID of this resource.
 - `path` (String) Absolute path to the Sequential ZNode, once it is created. The prefix of this will match `path_prefix`.
 - `stat` (List of Object) [ZooKeeper Stat Structure](https://zookeeper.apache.org/doc/current/zookeeperProgrammers.html#sc_zkStatStructure) of the ZNode. More details about `stat` can be found [here](../../docs#the-stat-structure). (see [below for nested schema](#nestedatt--stat))
+
+<a id="nestedblock--acl"></a>
+### Nested Schema for `acl`
+
+Required:
+
+- `id` (String) The ID for the ACL entry. For example, user:hash in 'digest' scheme.
+- `permissions` (Number) The permissions for the ACL entry, represented as an integer bitmask.
+- `scheme` (String) The ACL scheme, such as 'world', 'digest', 'ip', 'x509'.
+
 
 <a id="nestedatt--stat"></a>
 ### Nested Schema for `stat`

--- a/docs/resources/znode.md
+++ b/docs/resources/znode.md
@@ -35,6 +35,7 @@ resource "zookeeper_znode" "napoli_logo" {
 
 ### Optional
 
+- `acl` (Block List) List of ACL entries for the ZNode. (see [below for nested schema](#nestedblock--acl))
 - `data` (String) Content to store in the ZNode, as a UTF-8 string. Mutually exclusive with `data_base64`.
 - `data_base64` (String) Content to store in the ZNode, as Base64 encoded bytes. Mutually exclusive with `data`.
 
@@ -42,6 +43,16 @@ resource "zookeeper_znode" "napoli_logo" {
 
 - `id` (String) The ID of this resource.
 - `stat` (List of Object) [ZooKeeper Stat Structure](https://zookeeper.apache.org/doc/current/zookeeperProgrammers.html#sc_zkStatStructure) of the ZNode. More details about `stat` can be found [here](../../docs#the-stat-structure). (see [below for nested schema](#nestedatt--stat))
+
+<a id="nestedblock--acl"></a>
+### Nested Schema for `acl`
+
+Required:
+
+- `id` (String) The ID for the ACL entry. For example, user:hash in 'digest' scheme.
+- `permissions` (Number) The permissions for the ACL entry, represented as an integer bitmask.
+- `scheme` (String) The ACL scheme, such as 'world', 'digest', 'ip', 'x509'.
+
 
 <a id="nestedatt--stat"></a>
 ### Nested Schema for `stat`

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"github.com/go-zookeeper/zk"
 	"testing"
 
 	testifyAssert "github.com/stretchr/testify/assert"
@@ -25,7 +26,7 @@ func TestClassicCRUD(t *testing.T) {
 	assert.False(znodeExists)
 
 	// create
-	znode, err := client.Create("/test/ClassicCRUD", []byte("one"))
+	znode, err := client.Create("/test/ClassicCRUD", []byte("one"), zk.WorldACL(zk.PermAll))
 	assert.NoError(err)
 	assert.Equal("/test/ClassicCRUD", znode.Path)
 	assert.Equal([]byte("one"), znode.Data)
@@ -42,7 +43,7 @@ func TestClassicCRUD(t *testing.T) {
 	assert.Equal([]byte("one"), znode.Data)
 
 	// update
-	znode, err = client.Update("/test/ClassicCRUD", []byte("two"))
+	znode, err = client.Update("/test/ClassicCRUD", []byte("two"), zk.WorldACL(zk.PermAll))
 	assert.NoError(err)
 	assert.Equal("/test/ClassicCRUD", znode.Path)
 	assert.Equal([]byte("two"), znode.Data)
@@ -69,11 +70,11 @@ func TestClassicCRUD(t *testing.T) {
 func TestCreateSequential(t *testing.T) {
 	client, assert := initTest(t)
 
-	noPrefixSeqZNode, err := client.CreateSequential("/test/CreateSequential/", []byte("seq"))
+	noPrefixSeqZNode, err := client.CreateSequential("/test/CreateSequential/", []byte("seq"), zk.WorldACL(zk.PermAll))
 	assert.NoError(err)
 	assert.Equal("/test/CreateSequential/0000000000", noPrefixSeqZNode.Path)
 
-	prefixSeqZNode, err := client.CreateSequential("/test/CreateSequentialWithPrefix/prefix-", []byte("seq"))
+	prefixSeqZNode, err := client.CreateSequential("/test/CreateSequentialWithPrefix/prefix-", []byte("seq"), zk.WorldACL(zk.PermAll))
 	assert.NoError(err)
 	assert.Equal("/test/CreateSequentialWithPrefix/prefix-0000000000", prefixSeqZNode.Path)
 
@@ -85,7 +86,7 @@ func TestCreateSequential(t *testing.T) {
 func TestFailureWhenCreatingForNonSequentialZNodeEndingInSlash(t *testing.T) {
 	client, assert := initTest(t)
 
-	_, err := client.Create("/test/willFail/", nil)
+	_, err := client.Create("/test/willFail/", nil, zk.WorldACL(zk.PermAll))
 	assert.Error(err)
 	assert.Equal("non-sequential ZNode cannot have path '/test/willFail/' because it ends in '/'", err.Error())
 }
@@ -93,11 +94,11 @@ func TestFailureWhenCreatingForNonSequentialZNodeEndingInSlash(t *testing.T) {
 func TestFailureWhenCreatingWhenZNodeAlreadyExists(t *testing.T) {
 	client, assert := initTest(t)
 
-	_, err := client.Create("/test/node", nil)
+	_, err := client.Create("/test/node", nil, zk.WorldACL(zk.PermAll))
 	assert.NoError(err)
-	_, err = client.Create("/test/node", nil)
+	_, err = client.Create("/test/node", nil, zk.WorldACL(zk.PermAll))
 	assert.Error(err)
-	assert.Equal("failed to create ZNode '/test/node' (size: 0, createFlags: 0, acl: [{15 world anyone}]): zk: node already exists", err.Error())
+	assert.Equal("failed to create ZNode '/test/node' (size: 0, createFlags: 0, acl: [{31 world anyone}]): zk: node already exists", err.Error())
 
 	err = client.Delete("/test")
 	assert.NoError(err)
@@ -110,7 +111,7 @@ func TestFailureWithNonExistingZNodes(t *testing.T) {
 	assert.Error(err)
 	assert.Equal("failed to read ZNode '/does-not-exist': zk: node does not exist", err.Error())
 
-	_, err = client.Update("/also-does-not-exist", nil)
+	_, err = client.Update("/also-does-not-exist", nil, zk.WorldACL(zk.PermAll))
 	assert.Error(err)
 	assert.Equal("failed to update ZNode '/also-does-not-exist': does not exist", err.Error())
 }

--- a/internal/provider/data_source_znode.go
+++ b/internal/provider/data_source_znode.go
@@ -31,7 +31,6 @@ func datasourceZNode() *schema.Resource {
 			"stat": statSchema(),
 			"acl": {
 				Type:        schema.TypeList,
-				Optional:    true,
 				Computed:    true,
 				Description: "List of ACL entries for the ZNode.",
 				Elem: &schema.Resource{

--- a/internal/provider/data_source_znode.go
+++ b/internal/provider/data_source_znode.go
@@ -29,6 +29,34 @@ func datasourceZNode() *schema.Resource {
 					"Use this if content is binary (i.e. sequence of bytes).",
 			},
 			"stat": statSchema(),
+			"acl": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "List of ACL entries for the ZNode.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"scheme": {
+							Type:     schema.TypeString,
+							Required: true,
+							Description: "The ACL scheme, such as 'world', 'digest', " +
+								"'ip', 'x509'.",
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+							Description: "The ID for the ACL entry. For example, " +
+								"user:hash in 'digest' scheme.",
+						},
+						"permissions": {
+							Type:     schema.TypeInt,
+							Required: true,
+							Description: "The permissions for the ACL entry, " +
+								"represented as an integer bitmask.",
+						},
+					},
+				},
+			},
 		},
 		Description: "Provides access to the content of a " +
 			zNodeLinkForDesc + ". " +

--- a/internal/provider/data_source_znode_test.go
+++ b/internal/provider/data_source_znode_test.go
@@ -23,7 +23,8 @@ func TestAccDataSourceZNode(t *testing.T) {
 						data = "Forza Napoli!"
 					}
 					data "zookeeper_znode" "dst" {
-						path = zookeeper_znode.src.path
+						depends_on = [zookeeper_znode.src]
+						path 	   = zookeeper_znode.src.path
 					}`, srcPath,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/provider/data_source_znode_test.go
+++ b/internal/provider/data_source_znode_test.go
@@ -59,6 +59,13 @@ func TestAccDataSourceZNode(t *testing.T) {
 
 					resource.TestCheckResourceAttrPair("data.zookeeper_znode.dst", "stat.0.num_children", "zookeeper_znode.src", "stat.0.num_children"),
 					resource.TestCheckResourceAttr("data.zookeeper_znode.dst", "stat.0.num_children", "0"),
+
+					resource.TestCheckResourceAttrPair("data.zookeeper_znode.dst", "acl.0.scheme", "zookeeper_znode.src", "acl.0.scheme"),
+					resource.TestCheckResourceAttr("data.zookeeper_znode.dst", "acl.0.scheme", "world"),
+					resource.TestCheckResourceAttrPair("data.zookeeper_znode.dst", "acl.0.id", "zookeeper_znode.src", "acl.0.id"),
+					resource.TestCheckResourceAttr("data.zookeeper_znode.dst", "acl.0.id", "anyone"),
+					resource.TestCheckResourceAttrPair("data.zookeeper_znode.dst", "acl.0.permissions", "zookeeper_znode.src", "acl.0.permissions"),
+					resource.TestCheckResourceAttr("data.zookeeper_znode.dst", "acl.0.permissions", "31"),
 				),
 			},
 		},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -26,6 +26,18 @@ func New() (*schema.Provider, error) {
 				Description: "How many seconds a session is considered valid after losing connectivity. " +
 					"More information about ZooKeeper sessions can be found [here](#zookeeper-sessions).",
 			},
+			"username": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Username for digest authentication",
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Password for digest authentication",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"zookeeper_znode":            resourceZNode(),
@@ -41,9 +53,11 @@ func New() (*schema.Provider, error) {
 func configureProviderContext(_ context.Context, rscData *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	servers := rscData.Get("servers").(string)
 	sessionTimeout := rscData.Get("session_timeout").(int)
+	username := rscData.Get("username").(string)
+	password := rscData.Get("password").(string)
 
 	if servers != "" {
-		c, err := client.NewClient(servers, sessionTimeout)
+		c, err := client.NewClient(servers, sessionTimeout, username, password)
 
 		if err != nil {
 			// Report inability to connect internal Client

--- a/internal/provider/resource_sequential_znode_test.go
+++ b/internal/provider/resource_sequential_znode_test.go
@@ -70,3 +70,78 @@ func TestAccResourceSeqZNode_FromPrefix(t *testing.T) {
 		},
 	})
 }
+
+func TestAccResourceSeqZNode_DefaultACL(t *testing.T) {
+	seqFromDir := "/" + acctest.RandString(10) + "/"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { checkPreconditions(t) },
+		ProviderFactories: providerFactoriesMap(),
+		CheckDestroy:      confirmAllZNodeDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "zookeeper_sequential_znode" "default_acl" {
+						path_prefix = "%s"
+						data = "sequential znode created with default acl"
+					}`, seqFromDir,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("zookeeper_sequential_znode.default_acl", "path", regexp.MustCompile(`^`+seqFromDir+`\d{10}`)),
+					resource.TestCheckResourceAttrPair("zookeeper_sequential_znode.default_acl", "path", "zookeeper_sequential_znode.default_acl", "id"),
+					resource.TestCheckResourceAttr("zookeeper_sequential_znode.default_acl", "data", "sequential znode created with default acl"),
+					resource.TestCheckResourceAttr("zookeeper_sequential_znode.default_acl", "data_base64", "c2VxdWVudGlhbCB6bm9kZSBjcmVhdGVkIHdpdGggZGVmYXVsdCBhY2w="),
+					resource.TestCheckResourceAttr("zookeeper_sequential_znode.default_acl", "acl.#", "1"),
+					resource.TestCheckResourceAttr("zookeeper_sequential_znode.default_acl", "acl.0.scheme", "world"),
+					resource.TestCheckResourceAttr("zookeeper_sequential_znode.default_acl", "acl.0.id", "anyone"),
+					resource.TestCheckResourceAttr("zookeeper_sequential_znode.default_acl", "acl.0.permissions", "31"),
+				),
+			},
+			{
+				ResourceName:      "zookeeper_sequential_znode.default_acl",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceSeqZNode_WithACL(t *testing.T) {
+	seqFromDir := "/" + acctest.RandString(10) + "/"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { checkPreconditions(t) },
+		ProviderFactories: providerFactoriesMap(),
+		CheckDestroy:      confirmAllZNodeDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "zookeeper_sequential_znode" "with_acl" {
+						path_prefix = "%s"
+						data = "sequential znode created with acl"
+						acl {
+							scheme      = "world"
+							id          = "anyone"
+							permissions = 31
+						}
+					}`, seqFromDir,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("zookeeper_sequential_znode.with_acl", "path", regexp.MustCompile(`^`+seqFromDir+`\d{10}`)),
+					resource.TestCheckResourceAttrPair("zookeeper_sequential_znode.with_acl", "path", "zookeeper_sequential_znode.with_acl", "id"),
+					resource.TestCheckResourceAttr("zookeeper_sequential_znode.with_acl", "data", "sequential znode created with acl"),
+					resource.TestCheckResourceAttr("zookeeper_sequential_znode.with_acl", "data_base64", "c2VxdWVudGlhbCB6bm9kZSBjcmVhdGVkIHdpdGggYWNs"),
+					resource.TestCheckResourceAttr("zookeeper_sequential_znode.with_acl", "acl.#", "1"),
+					resource.TestCheckResourceAttr("zookeeper_sequential_znode.with_acl", "acl.0.scheme", "world"),
+					resource.TestCheckResourceAttr("zookeeper_sequential_znode.with_acl", "acl.0.id", "anyone"),
+					resource.TestCheckResourceAttr("zookeeper_sequential_znode.with_acl", "acl.0.permissions", "31"),
+				),
+			},
+			{
+				ResourceName:      "zookeeper_sequential_znode.with_acl",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_znode_test.go
+++ b/internal/provider/resource_znode_test.go
@@ -132,3 +132,62 @@ func TestAccResourceZNode_Base64(t *testing.T) {
 		},
 	})
 }
+
+func TestAccResourceZNode_DefaultACL(t *testing.T) {
+	path := "/" + acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { checkPreconditions(t) },
+		ProviderFactories: providerFactoriesMap(),
+		CheckDestroy:      confirmAllZNodeDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "zookeeper_znode" "test_default_acl" {
+						path = "%s"
+						data = "Default ACL Test"
+					}`, path),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("zookeeper_znode.test_default_acl", "path", path),
+					resource.TestCheckResourceAttr("zookeeper_znode.test_default_acl", "data", "Default ACL Test"),
+					resource.TestCheckResourceAttr("zookeeper_znode.test_default_acl", "acl.#", "1"),
+					resource.TestCheckResourceAttr("zookeeper_znode.test_default_acl", "acl.0.scheme", "world"),
+					resource.TestCheckResourceAttr("zookeeper_znode.test_default_acl", "acl.0.id", "anyone"),
+					resource.TestCheckResourceAttr("zookeeper_znode.test_default_acl", "acl.0.permissions", "31"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceZNode_WithACL(t *testing.T) {
+	path := "/" + acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { checkPreconditions(t) },
+		ProviderFactories: providerFactoriesMap(),
+		CheckDestroy:      confirmAllZNodeDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "zookeeper_znode" "test_acl" {
+						path = "%s"
+						data = "ACL Test"
+						acl {
+							scheme      = "world"
+							id          = "anyone"
+							permissions = 31
+						}
+					}`, path),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("zookeeper_znode.test_acl", "path", path),
+					resource.TestCheckResourceAttr("zookeeper_znode.test_acl", "data", "ACL Test"),
+					resource.TestCheckResourceAttr("zookeeper_znode.test_acl", "acl.#", "1"),
+					resource.TestCheckResourceAttr("zookeeper_znode.test_acl", "acl.0.scheme", "world"),
+					resource.TestCheckResourceAttr("zookeeper_znode.test_acl", "acl.0.id", "anyone"),
+					resource.TestCheckResourceAttr("zookeeper_znode.test_acl", "acl.0.permissions", "31"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Added username and password optional fields into the provider configuration. Only digest auth is supported.